### PR TITLE
Handle checking automate version

### DIFF
--- a/automate/controls/issues.rb
+++ b/automate/controls/issues.rb
@@ -41,3 +41,22 @@ control 'gatherlogs.automate.logstash-out-of-memory' do
     it { should_not exist }
   end
 end
+
+automate = installed_packages('automate')
+
+control "gatherlogs.automate.broken-reaper-cron-file-1.8.3" do
+  title "Check for version of Automate with broken reaper cron file"
+  desc "
+  It appears you are running Automate 1.8.3, which creates a broken reaper cron
+  file in `/etc/cron.d/reaper`. Cron requires that the file contains a blank line
+  before the end of the file and will fail to run if it's not included.
+
+  Please upgrade to a newer version of Automate to ensure reaper run correctly.
+  "
+
+  impact 1.0
+
+  describe automate do
+    its('version') { should_not cmp == '1.8.3'}
+  end
+end

--- a/glresources/libraries/installed_packages.rb
+++ b/glresources/libraries/installed_packages.rb
@@ -3,6 +3,11 @@ class InstalledPackages < Inspec.resource(1)
   desc 'attempt to detect the chef product'
 
   def initialize(name)
+    # This is needed because automate-ctl gatherlogs doesn't include a
+    # `installed-packages.txt`
+    # Also, the method used for exist? on Automate is not ideal as another
+    # product could include version-manifest.json and would give a false postive
+    # if requesting the automate package version.
     if name == 'automate'
       filename = 'opt/delivery/version-manifest.json'
       @package = AutomateVersionManifestJson.new(name, read_content(filename))

--- a/glresources/libraries/installed_packages.rb
+++ b/glresources/libraries/installed_packages.rb
@@ -62,7 +62,7 @@ class InstalledPackagesTxt
   def package_version(os)
     return unless exist?
 
-    case os
+    case os.to_sym
     when :rhel
       result = content.match(/#{@package_name}-(\d+\.\d+\.\d+)-\d+.\w.\w/)
       result[1] unless result.nil?

--- a/glresources/libraries/installed_packages.rb
+++ b/glresources/libraries/installed_packages.rb
@@ -2,53 +2,91 @@ class InstalledPackages < Inspec.resource(1)
   name 'installed_packages'
   desc 'attempt to detect the chef product'
 
-  attr_accessor :content
-
   def initialize(name)
-    @content ||= read_content
-    @package_name = name
+    if name == 'automate'
+      filename = 'opt/delivery/version-manifest.json'
+      @package = AutomateVersionManifestJson.new(name, read_content(filename))
+    else
+      filename = 'installed-packages.txt'
+      @package = InstalledPackagesTxt.new(name, read_content(filename), platform_version.os)
+    end
   end
 
   def exist?
-    content && content.match?(@package_name)
+    @package.exist?
   end
-
   alias_method :exists?, :exist?
 
   def version
-    package_version(@package_name)
+    @package.version
   end
 
   private
+
+  def read_content(filename)
+    f = inspec.file(filename)
+    if f.file?
+      f.content
+    else
+      puts 'foo'
+      nil
+    end
+  end
 
   # This is an ugly hack to get around a bug where other custom resources
   # are not available inside a custom resource.
   def platform_version
     self.class.__resource_registry['platform_version'].new(inspec, 'platform_version')
   end
+end
 
-  def package_version(name)
-    return unless self.exists?
-    
-    case platform_version.os
-    # case :rhel
-    when :rhel
-      result = content.match(/#{name}-(\d+\.\d+\.\d+)-\d+.\w.\w/)
-      result[1] unless result.nil?
-    when :ubuntu
-      result = content.match(/#{name}\s+(\d+\.\d+\.\d+)/)
-      result[1] unless result.nil?
-    else
-      raise Inspec::Exceptions::ResourceSkipped, "installed_packages currently doesn't support #{platform_version.os.inspect}"
-    end
+class InstalledPackagesTxt
+  attr_accessor :content, :version
+
+  def initialize(name, packages_content, os)
+    @package_name = name
+    @content = packages_content
+    @version = package_version(os.to_sym)
   end
 
-  def read_content
-    f = inspec.file('installed-packages.txt')
-    if f.file?
-      f.content
+  def exist?
+    content && content.match?(@package_name)
+  end
+
+  private
+
+  def package_version(os)
+    return unless exist?
+
+    case os
+    when :rhel
+      result = content.match(/#{@package_name}-(\d+\.\d+\.\d+)-\d+.\w.\w/)
+      result[1] unless result.nil?
+    when :ubuntu
+      result = content.match(/#{@package_name}\s+(\d+\.\d+\.\d+)/)
+      result[1] unless result.nil?
     else
-      raise Inspec::Exceptions::ResourceSkipped, "Can't read installed-packages.txt"
+      nil
     end
+  end
+end
+
+class AutomateVersionManifestJson
+  attr_accessor :content, :version
+
+  def initialize(name, packages_content)
+    @content = JSON.parse(packages_content)
+    @package_name = name
+    @version = package_version
+  end
+
+  def exist?
+    !content.nil?
+  end
+
+  private
+
+  def package_version
+    content['build_version']
   end
 end

--- a/glresources/libraries/installed_packages.rb
+++ b/glresources/libraries/installed_packages.rb
@@ -33,7 +33,6 @@ class InstalledPackages < Inspec.resource(1)
     if f.file?
       f.content
     else
-      puts 'foo'
       nil
     end
   end


### PR DESCRIPTION
It doesn't appear that `automate-ctl gather-logs` includes a `installed-packages.txt` file so we need to check for the version-manifest.txt to attempt to determine the version.