### PR TITLE
Adding checks preflight failures for A2

### DIFF
--- a/automate2/controls/basic.rb
+++ b/automate2/controls/basic.rb
@@ -91,3 +91,25 @@ control "gatherlogs.automate2.sysctl-settings" do
     its('vm_dirty_expire_centisecs') { should cmp <= 30000 }
   end
 end
+
+failed_preflight_checks = log_analysis("chef-automate_preflight-check.txt", 'FAIL')
+control "gatherlogs.automate2.failed_preflight_checks" do
+  impact 1.0
+  title 'Check automate preflight output for any failed tests'
+  desc "
+Automate preflight checks are reporting issues failures, the failure for 'automate already deployed'
+is expected but other failures are being reported.
+
+If sysctl settings are being reported as failed be sure to update your 'syctl.conf'
+with the required settings to ensure they persist through system reboots
+
+Please check the chef-automate_preflight-check.txt for ways to remediate the failed tests.
+
+Failed checks:
+#{failed_preflight_checks.messages.join("\n")}
+  "
+
+  describe failed_preflight_checks do
+    its('hits') { should cmp == 1 }
+  end
+end

--- a/glresources/libraries/log_analysis.rb
+++ b/glresources/libraries/log_analysis.rb
@@ -2,7 +2,7 @@ class LogAnalysis < Inspec.resource(1)
   name 'log_analysis'
   desc 'Parse log files to find issues'
 
-  attr_accessor :logfile, :grep_expr
+  attr_accessor :logfile, :grep_expr, :messages
   def initialize(log, expr)
     @grep_expr = expr
     @logfile = log


### PR DESCRIPTION
Currently this is adding support for preflight checks from Automate v2

![automate2 zsh 2018-07-06 10-01-11](https://user-images.githubusercontent.com/3766/42391224-87401528-8103-11e8-9631-b1b3e10d2c9e.png)
