### PR TITLE
Add automate2 issue controls

### DIFF
--- a/automate2/controls/issues.rb
+++ b/automate2/controls/issues.rb
@@ -3,15 +3,15 @@
 upgrade_failed = log_analysis("journalctl_chef-automate.txt", 'level=error msg="Phase failed" error="hab-sup upgrade pending" phase="supervisor upgrade"', a2service: 'service.default')
 control "gatherlogs.automate2.upgrade_failed" do
   impact 1.0
-  title 'Automate is reporting a failure during the upgrade process'
+  title 'Check to see if Automate is reporting a failure during the hab sup upgrade process'
   desc "
 It appears that there was a failure during the upgrade process for Automate, please
 check the logs and contact support to see about getting this fixed.
-  
+
 #{upgrade_failed.summary}
   "
 
   describe upgrade_failed do
-    its('hits') { should cmp <= 10 }
+    its('last_entry') { should be_empty }
   end
 end

--- a/automate2/controls/issues.rb
+++ b/automate2/controls/issues.rb
@@ -1,0 +1,17 @@
+#level=error msg="Phase failed" error="hab-sup upgrade pending" phase="supervisor upgrade"
+
+upgrade_failed = log_analysis("journalctl_chef-automate.txt", 'level=error msg="Phase failed" error="hab-sup upgrade pending" phase="supervisor upgrade"', a2service: 'service.default')
+control "gatherlogs.automate2.upgrade_failed" do
+  impact 1.0
+  title 'Automate is reporting a failure during the upgrade process'
+  desc "
+It appears that there was a failure during the upgrade process for Automate, please
+check the logs and contact support to see about getting this fixed.
+  
+#{upgrade_failed.summary}
+  "
+
+  describe upgrade_failed do
+    its('hits') { should cmp <= 10 }
+  end
+end

--- a/bin/check_logs
+++ b/bin/check_logs
@@ -42,4 +42,5 @@ Options:
   esac
 done
 
+echo "Running inspec..."
 inspec exec $profiles --reporter json | $DIR/pretty.rb $args


### PR DESCRIPTION
This adds a check when the `hab sub` upgrade fails

![automate2 zsh 2018-07-11 13-29-30](https://user-images.githubusercontent.com/3766/42597697-7d47ec44-850e-11e8-869c-253a919db0ce.png)
