### PR TITLE
Fix up service checks for a2 to look at health

### DIFF
--- a/automate2/controls/basic.rb
+++ b/automate2/controls/basic.rb
@@ -26,20 +26,23 @@ services.internal do |service|
   control "gatherlogs.automate2.internal_service_status.#{service.name}" do
     title "check that #{service.name} service is running"
     desc "
-    Internal #{service.name} service is not running or has a short runtime, check the logs
-    and make sure the service is not flapping.
+    There was a problem with the #{service.name} service.  Please check that it's
+    running, doesn't have a short run time, or the health checks are reporting an issue.
+
+    #{service.summary}
     "
 
     describe service do
       its('status') { should eq 'running' }
-      its('runtime') { should cmp >= 80 }
+      its('health') { should eq 'ok' }
+      its('runtime') { should cmp >= 90 }
     end
   end
 end
 
 df = disk_usage()
 
-%w(/ /hab /var/log).each do |mount|
+%w(/ /hab /var /var/log).each do |mount|
   control "gatherlogs.automate2.critical_disk_usage.#{mount}" do
     title "check that the automate has plenty of free space"
     desc "

--- a/automate2/controls/issues.rb
+++ b/automate2/controls/issues.rb
@@ -85,6 +85,12 @@ Automate is reporting that the vm.max_map_count is not set correctly. This is a 
 that should be checked by the automate pre-flight tests.  If you recently rebooted make sure
 the settings are set in /etc/sysctl.conf
 
+Fix the system tuning failures indicated above by running the following:
+sysctl -w vm.max_map_count=262144
+
+To make these changes permanent, add the following to /etc/sysctl.conf:
+vm.max_map_count=262144
+
 #{es_vmc.summary}
   "
 

--- a/automate2/inspec.yml
+++ b/automate2/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for automate2 generated gather-logs
-version: 0.1.3
+version: 0.1.4
 
 depends:
   - name: common

--- a/glresources/inspec.yml
+++ b/glresources/inspec.yml
@@ -5,4 +5,4 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: This contains custom resources for inspec for parsing files from chef-product gatherlogs
-version: 0.1.6
+version: 0.1.7

--- a/glresources/libraries/service_status.rb
+++ b/glresources/libraries/service_status.rb
@@ -111,6 +111,13 @@ class ServiceObject
     @args[field.to_sym] if @args.has_key?(field.to_sym)
   end
 
+  def summary
+    %w{ name status runtime health }.map { |key|
+      next unless @args.include?(key.to_sym)
+      "#{key.capitalize}: #{@args[key.to_sym]}"
+    }.join(', ')
+  end
+
   def to_s
     @args[:name] || 'Unknown'
   end


### PR DESCRIPTION
Adds a new summary method for the service status and also updates a2 to
look for the health check output for services

Signed-off-by: Will Fisher <wfisher@chef.io>