### PR TITLE
Fix output if no failures from inspec

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,17 @@
+# Building hab pkg
+
+This is the instructions for building and promoting the hab pkg
+
+##
+
+```
+hab studio enter
+build
+# test the build
+sup-log &
+hab svc unload will/gatherlogs
+hab svc load will/gatherlogs
+# upload and promote
+source results/last_build.env; hab pkg upload results/$pkg_artifact
+source results/last_build.env; hab pkg promote $pkg_ident stable
+```

--- a/bin/server
+++ b/bin/server
@@ -48,6 +48,7 @@ get '/zendesk/:token' do
 
       results = server.check_logs(attachment)
       server.update_zendesk(ticket_info['ticket_id'].to_i, filename, results)
+      puts results.to_json
 
       status 204
     end


### PR DESCRIPTION
~in the same comment and~ also updates ugly output when there are no
failures returned by the inspec profiles

Turns out the fix is in the zendesk trigger and not here for multiple attachments

Signed-off-by: Will Fisher <wfisher@chef.io>