### PR TITLE
Turns out that on linux we need to use perl regexp

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,7 @@ Style/NumericPredicate:
 
 Metrics/ClassLength:
   Max: 200
+
+# These are ugly 
+Style/ConditionalAssignment:
+  Enabled: false

--- a/profiles/glresources/libraries/log_analysis.rb
+++ b/profiles/glresources/libraries/log_analysis.rb
@@ -62,10 +62,17 @@ class LogAnalysis < Inspec.resource(1)
 
     return [] unless File.exist?(logfile)
 
+    if inspec.os.family == 'darwin'
+      grep_flag = '-E'
+    else
+      grep_flag = '-P'
+    end
+
+
     cmd << if @options[:a2service]
-             "grep -i '#{@options[:a2service]}' #{logfile} | grep -iE '#{grep_expr}'"
+             "grep -i '#{@options[:a2service]}' #{logfile} | grep -i #{grep_flag} '#{grep_expr}'"
            else
-             "grep -iE '#{grep_expr}' #{logfile}"
+             "grep -i #{grep_flag} '#{grep_expr}' #{logfile}"
            end
 
     command = inspec.command(cmd.join(' | '))

--- a/profiles/glresources/libraries/log_analysis.rb
+++ b/profiles/glresources/libraries/log_analysis.rb
@@ -68,7 +68,6 @@ class LogAnalysis < Inspec.resource(1)
       grep_flag = '-P'
     end
 
-
     cmd << if @options[:a2service]
              "grep -i '#{@options[:a2service]}' #{logfile} | grep -i #{grep_flag} '#{grep_expr}'"
            else


### PR DESCRIPTION
Grep that comes with MacOS works fine using extended regexp but in order
for some of the matchers to work right the hab/linux version needs to
  use perl.

Signed-off-by: Will Fisher <wfisher@chef.io>