### PR TITLE
Fix the sysctl custom resource for inspec

### DIFF
--- a/profiles/automate/controls/basic.rb
+++ b/profiles/automate/controls/basic.rb
@@ -84,7 +84,7 @@ df = disk_usage
       There are several key directories that we need to make sure have enough
       free space for automate to operate succesfully
     "
-
+    tag verbose: true
     only_if { df.exists?(mount) }
 
     describe df.mount(mount) do
@@ -100,6 +100,7 @@ control 'gatherlogs.automate.sysctl-settings' do
     Recommended sysctl settings are not correct, recommend that these get updated
     to ensure the best performance possible for Automate.
   "
+  tag verbose: true
   only_if { sysctl.exists? }
   describe sysctl do
     its('vm_swappiness') { should cmp >= 1 }

--- a/profiles/automate2/inspec.yml
+++ b/profiles/automate2/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for automate2 generated gather-logs
-version: 0.3.2
+version: 0.3.3
 
 depends:
   - name: common

--- a/profiles/glresources/inspec.yml
+++ b/profiles/glresources/inspec.yml
@@ -5,4 +5,4 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: This contains custom resources for inspec for parsing files from chef-product gatherlogs
-version: 0.4.2
+version: 0.4.3

--- a/profiles/glresources/libraries/sysctl.rb
+++ b/profiles/glresources/libraries/sysctl.rb
@@ -2,8 +2,9 @@ class Sysctl < Inspec.resource(1)
   name 'sysctl'
   desc 'Parse the sysctl config'
 
-  def initialize(filename = 'sysctl.txt')
-    @content = parse_sysctl(read_content(filename))
+  def initialize(filename = 'sysctl_a.txt')
+    @filename = filename
+    @content = parse_sysctl(read_content)
   end
 
   def method_missing(name)
@@ -15,7 +16,7 @@ class Sysctl < Inspec.resource(1)
   end
 
   def exists?
-    !@content.empty?
+    sysctl_file.exist?
   end
 
   private
@@ -36,12 +37,13 @@ class Sysctl < Inspec.resource(1)
     data
   end
 
-  def read_content(filename)
-    f = inspec.file(filename)
-    if f.file?
-      f.content
-    else
-      ''
-    end
+  def sysctl_file
+    inspec.file(@filename)
+  end
+
+  def read_content
+    return '' unless sysctl_file.exist?
+
+    sysctl_file.content
   end
 end


### PR DESCRIPTION
I recently broke this when I renamed the class to sysctl from sysctl_a

Signed-off-by: Will Fisher <wfisher@chef.io>