### PR TITLE
Fix uptime and cpu info not showing up

### DIFF
--- a/lib/gatherlogs/control_report.rb
+++ b/lib/gatherlogs/control_report.rb
@@ -78,16 +78,17 @@ module Gatherlogs
     end
 
     def process_control(control)
-      # included controls show up in the parent but with no results
-      # so we need to skip them
-      return if control['results'].empty?
-
       report = []
       @status = PASSED
       @badge = PASSED_ICON
       @verbose = false
 
       update_system_info(control['tags'])
+
+      # included controls show up in the parent but with no results
+      # so we need to skip them but make sure to grab sys info first
+      return if control['results'].empty?
+
       update_verbose_control(control['tags'])
 
       result_messages = control['results'].map do |result|


### PR DESCRIPTION
This was happening because we were skipping any controls that had no
results.  This moves the pull of system info to before the skip

Signed-off-by: Will Fisher <wfisher@chef.io>