### PR TITLE
Use tail to limit number of lines we search for in log files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,6 @@ Metrics/ClassLength:
 # These are ugly 
 Style/ConditionalAssignment:
   Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false

--- a/profiles/glresources/inspec.yml
+++ b/profiles/glresources/inspec.yml
@@ -5,4 +5,4 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: This contains custom resources for inspec for parsing files from chef-product gatherlogs
-version: 0.4.5
+version: 0.5.0

--- a/profiles/glresources/libraries/log_analysis.rb
+++ b/profiles/glresources/libraries/log_analysis.rb
@@ -68,8 +68,10 @@ class LogAnalysis < Inspec.resource(1)
     flags += '-i ' if @options[:case_sensitive] != true
     flags += inspec.os.family == 'darwin' ? '-E' : '-P'
 
+    @options[:log_limit] ||= 100000
     if @options[:a2service]
-      cmd << "grep -i '#{@options[:a2service]}' #{logfile}"
+      cmd << "tail -n#{@options[:log_limit]} #{logfile}"
+      cmd << "grep -i '#{@options[:a2service]}'"
       cmd << "grep #{flags} '#{search}'"
     else
       cmd << "grep #{flags} '#{search}' #{logfile}"


### PR DESCRIPTION
This defaults to a really high value (100000 lines) that should only impact journalctl logs from A2.  Gatherlogs from other products already limits files to 10K lines.