### PR TITLE
Find when workflow runner terminated

### DIFF
--- a/profiles/automate/controls/workflow.rb
+++ b/profiles/automate/controls/workflow.rb
@@ -1,0 +1,18 @@
+# you add controls here
+control 'gatherlogs.automate.runner_worker_terminated' do
+  impact 0.5
+  title 'Check to see the runner process was terminated'
+  desc '
+The Automate process that manage workers information was terminated.
+
+To resolve this issue restart the delivery service.
+  '
+
+  %w[console.log current].each do |logfile|
+    runner_worker_terminated = log_analysis(::File.join('var/log/delivery/delivery', logfile), 'terminated with reason:.*jobs_queue')
+    tag summary: runner_worker_terminated.summary
+    describe runner_worker_terminated do # The actual test
+      its('last_entry') { should be_empty }
+    end
+  end
+end

--- a/profiles/automate/inspec.yml
+++ b/profiles/automate/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for automate generated gather-logs
-version: 0.3.3
+version: 0.3.4
 
 depends:
   - name: common


### PR DESCRIPTION
It's possible that the process that manages status of workflow's runners
was terminated.  This finds when that happens

Signed-off-by: Will Fisher <wfisher@chef.io>