### PR TITLE
Fix tar permissions

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -5,8 +5,8 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/tar
   core/bzip2
-  core/wget/1.19.4/20180608102523 # need to pin because inspec uses old version of openssl
-  core/ruby/2.5.1/20180702162818 # need to pin because inspec uses old version of openssl
+  core/wget
+  core/ruby
   core/gzip
   core/file
   core/grep

--- a/lib/gatherlogs/cli.rb
+++ b/lib/gatherlogs/cli.rb
@@ -64,6 +64,11 @@ module Gatherlogs
       return show_profiles if list_profiles?
 
       generate_report
+    ensure
+      @cleanup_paths.each do |d|
+        debug "cleaning up #{d}"
+        FileUtils.remove_entry(d, true)
+      end
     end
 
     def generate_report
@@ -136,11 +141,6 @@ module Gatherlogs
 
       debug("Using log_path: #{current_log_path}")
       yield current_log_path
-    ensure
-      @cleanup_paths.each do |d|
-        debug "cleaning up #{d}"
-        FileUtils.remove_entry(d, true)
-      end
     end
 
     def extract_remote_file(url)

--- a/lib/gatherlogs/cli.rb
+++ b/lib/gatherlogs/cli.rb
@@ -15,7 +15,7 @@ module Gatherlogs
     include Gatherlogs::Output
     include Gatherlogs::Shellout
 
-    attr_accessor :current_log_path, :tmp_cache_file
+    attr_accessor :current_log_path
     attr_writer :profiles
 
     option ['-p', '--path'], 'PATH', 'Path to the gatherlogs for inspection',
@@ -42,7 +42,7 @@ module Gatherlogs
       enable_colors
       @profiles = nil
       @current_log_path = nil
-      @tmp_cache_file = nil
+      @cleanup_paths = []
     end
 
     def show_versions
@@ -131,20 +131,28 @@ module Gatherlogs
       current_log_path = if remote_url.nil?
                            log_path.dup
                          else
-                           fetch_remote_tar(remote_url)
+                           extract_remote_file(remote_url)
                          end
 
-      if File.directory?(current_log_path)
-        debug("Using log_path: #{current_log_path}")
-        return yield current_log_path
-      else
-        Dir.mktmpdir do |work_dir|
-          extract_bundle(current_log_path, work_dir)
-          return yield work_dir
-        end
-      end
+      debug("Using log_path: #{current_log_path}")
+      yield current_log_path
     ensure
-      tmp_cache_file&.unlink
+      @cleanup_paths.each do |d|
+        debug "cleaning up #{d}"
+        FileUtils.remove_entry(d, true)
+      end
+    end
+
+    def extract_remote_file(url)
+      remote_file = fetch_remote_tar(url)
+      return if remote_file.nil?
+
+      @cleanup_paths << (tmpdir = Dir.mktmpdir)
+      extract_bundle(remote_file, tmpdir)
+
+      tmpdir
+    ensure
+      FileUtils.remove_entry(remote_file, true)
     end
 
     def extract_bundle(filename, path)
@@ -153,19 +161,29 @@ module Gatherlogs
         '--strip-components', '2'
       ]
       shellout!(cmd)
+      fix_archive_perms(path)
+    end
+
+    # it's possible for an archive to set permissions that prevent us from
+    # accessing or removing files.  This fixes those permissions
+    def fix_archive_perms(path)
+      cmd = "find '#{path}' -type d -exec chmod 755 {} \\\;"
+      shellout!(cmd)
+      cmd = "find '#{path}' -type f -exec chmod 644 {} \\\;"
+      shellout!(cmd)
     end
 
     def fetch_remote_tar(url)
       return if url.nil?
 
       info 'Fetching remote gatherlogs bundle'
-      @tmp_cache_file = ::Tempfile.new('gatherlogs')
-      @tmp_cache_file.close
-      debug "tmp_cache_file: #{@tmp_cache_file}"
+      tmp_cache_file = ::Tempfile.new('gatherlogs')
+      tmp_cache_file.close
+      debug "tmp_cache_file: #{tmp_cache_file.path}"
 
-      shellout!(['wget', url, '-O', @tmp_cache_file.path])
+      shellout!(['wget', url, '-O', tmp_cache_file.path])
 
-      @tmp_cache_file.path
+      tmp_cache_file.path
     end
 
     def find_profile_path(profile)

--- a/spec/gatherlogs/cli_spec.rb
+++ b/spec/gatherlogs/cli_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe Gatherlogs::CLI do
         'tar', 'xvf', 'abc.gz', '-C', 'somepath', '--strip-components', '2'
       ]
     )
+    expect(cli).to receive(:shellout!).with(
+      "find 'somepath' -type d -exec chmod 755 {} \\;"
+    )
+    expect(cli).to receive(:shellout!).with(
+      "find 'somepath' -type f -exec chmod 644 {} \\;"
+    )
 
     cli.extract_bundle('abc.gz', 'somepath')
   end


### PR DESCRIPTION
It's possible for a tar file to set permissions that prevent us from accessing directories (missing execute permissions) or setting files as executable when they shouldn't be.  This ensure we have the correct access to all the files.