### PR TITLE
This migrates the A2 port usage check to be a common check

### DIFF
--- a/profiles/automate2/controls/issues.rb
+++ b/profiles/automate2/controls/issues.rb
@@ -186,21 +186,3 @@ chmod 0444 /hab/svc/deployment-service/data/Chef_Automate*.crt /hab/svc/deployme
     its('last_entry') { should be_empty }
   end
 end
-
-port_exhaustion = log_analysis('ss.txt', 'TIME-WAIT|ESTAB')
-control 'gatherlogs.automate2.port_exhaustion' do
-  title 'Check to see if all the available ports have been used by Automate'
-  desc "
-There appears to be a large number of open ports on the Automate system.  This
-can cause high cpu and memory usage on the system as services queue requests
-waiting for a port to become available for message processing.
-
-If the ports are being used by Automate you will need to restart the services
-using `chef-automate restart-services`
-  "
-
-  tag verbose: true
-  describe port_exhaustion do
-    its('count') { should be < 10000 }
-  end
-end

--- a/profiles/common/controls/basic.rb
+++ b/profiles/common/controls/basic.rb
@@ -113,3 +113,21 @@ kernel logs to see what might have lead to this event.
     its('last_entry') { should be_empty }
   end
 end
+
+
+common_logs.ss_ontap do |ss_ontap|
+  port_exhaustion = log_analysis(ss_ontap, 'TIME-WAIT|ESTAB')
+  control "gatherlogs.common.port_exhaustion.#{ss_ontap}" do
+    title 'Check to see if all the available ports have been used'
+    desc "
+  There appears to be a large number of open ports on the system.  This
+  can cause high cpu and memory usage on the system as services queue requests
+  waiting for a port to become available for message processing.
+    "
+
+    tag verbose: true
+    describe port_exhaustion do
+      its('count') { should be < 10000 }
+    end
+  end
+end

--- a/profiles/common/controls/basic.rb
+++ b/profiles/common/controls/basic.rb
@@ -122,6 +122,12 @@ common_logs.ss_ontap do |ss_ontap|
   There appears to be a large number of open ports on the system.  This
   can cause high cpu and memory usage on the system as services queue requests
   waiting for a port to become available for message processing.
+
+  This can sometimes happen if a service like ElasticSearch is unable to process
+  requests fast enough. Try restarting the Chef-Server/Automate services and
+  monitor the system to see if it starts to happen again. If so ensure there
+  are no performance issues with the system due to high I/O wait times or
+  other services using a large amount of memory.
     "
 
     tag verbose: true

--- a/profiles/common/controls/basic.rb
+++ b/profiles/common/controls/basic.rb
@@ -114,7 +114,6 @@ kernel logs to see what might have lead to this event.
   end
 end
 
-
 common_logs.ss_ontap do |ss_ontap|
   port_exhaustion = log_analysis(ss_ontap, 'TIME-WAIT|ESTAB')
   control "gatherlogs.common.port_exhaustion.#{ss_ontap}" do

--- a/profiles/glresources/libraries/common_logs.rb
+++ b/profiles/glresources/libraries/common_logs.rb
@@ -28,4 +28,14 @@ class CommonLogs < Inspec.resource(1)
       files
     end
   end
+
+  def ss_ontap
+    # automate 2 uses a different filename
+    files = %w[ss_ontap.txt ss.txt]
+    if block_given?
+      files.each { |f| yield f }
+    else
+      files
+    end
+  end
 end


### PR DESCRIPTION
Supports chef-server, automate and a2

This replaces #92 with a more generic check.

Signed-off-by: Will Fisher <wfisher@chef.io>