### PR TITLE
Move summary after the KB link

### DIFF
--- a/lib/gatherlogs/control_report.rb
+++ b/lib/gatherlogs/control_report.rb
@@ -135,8 +135,8 @@ module Gatherlogs
       summary << control_title(control)
       if @status == FAILED
         summary << subsection(desc_text(control))
-        summary << subsection(summary_text(control))
         summary << subsection(kb_text(control))
+        summary << subsection(summary_text(control))
       end
 
       summary


### PR DESCRIPTION
This moves the output of the test summary to after the KB link